### PR TITLE
Add liveness/readiness probes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.github/
+.tekton/
+bin/
+external/
+test/

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -24,6 +24,26 @@ spec:
             requests:
               memory: "64Mi"
               cpu: "10m"
+          livenessProbe:
+            httpGet:
+              port: downloads
+              scheme: "HTTP{{ if .Values.isOpenshift }}S{{ end }}"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              port: downloads
+              scheme: "HTTP{{ if .Values.isOpenshift }}S{{ end }}"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
           ports:
       {{- if not .Values.isOpenshift }}
             - containerPort: 8080
@@ -42,3 +62,8 @@ spec:
           secret:
             secretName: acm-cli-cert
       {{- end }}
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true

--- a/server/main.go
+++ b/server/main.go
@@ -37,6 +37,8 @@ func main() {
 		if len(missingFiles) > 0 {
 			log.Fatalf("error: Certificate files %s not found in /var/run/acm-cli-cert/\n", missingFiles)
 		}
+
+		port = "8443"
 	}
 
 	// Set up file server with timeouts


### PR DESCRIPTION
- Adds basic TCP probes.
- Adds fields that align with the MCH deployment.
- Adds `.dockerignore` file
