### PR TITLE
Provide `tar` for unpacking binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
 
 RUN microdnf update -y \
+    && microdnf install -y tar \
     && microdnf clean all
 
 # Copy binaries from builder

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -17,6 +17,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
 
 RUN microdnf update -y \
+    && microdnf install -y tar \
     && microdnf clean all
 
 # Copy binaries from builder


### PR DESCRIPTION
This allows things like using it as an init container with ArgoCD. It's not actually necessary to add downstream because the base image there is the full UBI and has `tar` already available.