### PR TITLE
Upgrade golangci-lint to 1.64.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/_output/
 bin/
 gosec.json
 kubeconfig_*
+.go/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.22-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.23-linux AS builder
 
-ENV RELEASE_TAG=release-2.13 \
+ENV RELEASE_TAG=release-2.14 \
     REPO_PATH=/go/src/github.com/stolostron/acm-cli
 
 WORKDIR ${REPO_PATH}

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,6 +1,6 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS builder
 
-ENV RELEASE_TAG=release-2.13 \
+ENV RELEASE_TAG=release-2.14 \
     REPO_PATH=/go/src/github.com/stolostron/acm-cli
 
 WORKDIR ${REPO_PATH}

--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -5,15 +5,15 @@
 # https://github.com/kubernetes-sigs/controller-tools/releases/latest
 CONTROLLER_GEN_VERSION := v0.16.3
 # https://github.com/kubernetes-sigs/kustomize/releases/latest
-KUSTOMIZE_VERSION := v5.4.3
+KUSTOMIZE_VERSION := v5.6.0
 # https://github.com/golangci/golangci-lint/releases/latest
-GOLANGCI_VERSION := v1.52.2
+GOLANGCI_VERSION := v1.64.8
 # https://github.com/mvdan/gofumpt/releases/latest
 GOFUMPT_VERSION := v0.7.0
 # https://github.com/daixiang0/gci/releases/latest
 GCI_VERSION := v0.13.5
 # https://github.com/securego/gosec/releases/latest
-GOSEC_VERSION := v2.21.3
+GOSEC_VERSION := v2.22.2
 # https://github.com/kubernetes-sigs/kubebuilder/releases/latest
 KBVERSION := 3.15.1
 # https://github.com/kubernetes/kubernetes/releases/latest

--- a/build/common/config/.golangci.yml
+++ b/build/common/config/.golangci.yml
@@ -24,6 +24,7 @@ run:
 linters:
   enable-all: true
   disable:
+    - mnd # Disabled as tech debt: Magic number detection
     - bodyclose
     # Disable contextcheck since we don't want to pass the context passed to PeriodicallyExecConfigPolicies to functions
     # called within it or else cleanup won't occur

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/stolostron/acm-cli
 
-go 1.22.0
+go 1.23.0

--- a/test/cli_list.html
+++ b/test/cli_list.html
@@ -1,3 +1,5 @@
+<!doctype html>
+<meta name="viewport" content="width=device-width">
 <pre>
 <a href="darwin-amd64-PolicyGenerator.tar.gz">darwin-amd64-PolicyGenerator.tar.gz</a>
 <a href="darwin-amd64-policytools.tar.gz">darwin-amd64-policytools.tar.gz</a>


### PR DESCRIPTION
- Upgrade golangci-lint to 1.64.8
- gosec => 2.22.2
- kustomize => 5.6.
- Upgrade go to 1.23