### PR TITLE
[release-2.12] fix: set branch for CLI versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM registry.ci.openshift.org/stolostron/builder:go1.23-linux AS builder
 
-ENV RELEASE_TAG=release-2.12 \
-    REPO_PATH=/go/src/github.com/stolostron/acm-cli
+ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
 
 WORKDIR ${REPO_PATH}
 

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,7 +1,6 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS builder
 
-ENV RELEASE_TAG=release-2.12 \
-    REPO_PATH=/go/src/github.com/stolostron/acm-cli
+ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
 
 WORKDIR ${REPO_PATH}
 

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ clean:
 ############################################################
 CONTAINER_ENGINE ?= podman
 BUILD_DIR ?= build/_output
-RELEASE_TAG ?= main
-REMOTE_SOURCES_DIR ?= $(PWD)/external
-REMOTE_SOURCES_SUBDIR ?= 
 
 .PHONY: build
 build:
@@ -68,8 +65,7 @@ sync-repos:
 
 .PHONY: build-binaries
 build-binaries:
-	BUILD_DIR=$(BUILD_DIR) REMOTE_SOURCES_DIR=$(REMOTE_SOURCES_DIR) REMOTE_SOURCES_SUBDIR=$(REMOTE_SOURCES_SUBDIR) \
-		./build/cli-builder.sh
+	BUILD_DIR=$(BUILD_DIR) ./build/cli-builder.sh
 
 .PHONY: package-binaries
 package-binaries:

--- a/build/cli-builder.sh
+++ b/build/cli-builder.sh
@@ -3,10 +3,8 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-
-REMOTE_SOURCES_DIR=${REMOTE_SOURCES_DIR:-${SCRIPT_DIR}/../external}
-REMOTE_SOURCES_SUBDIR=${REMOTE_SOURCES_SUBDIR:-}
-BUILD_DIR=${BUILD_DIR:-${SCRIPT_DIR}}
+BUILD_DIR=${BUILD_DIR:-"build/_output"}
+current_branch=$(git -C "${SCRIPT_DIR}/../" branch --show-current)
 
 while IFS=, read -r git_url build_cmd build_dir; do
   if [[ "${git_url}" == "GIT REPO URL" ]]; then
@@ -15,26 +13,31 @@ while IFS=, read -r git_url build_cmd build_dir; do
 
   git_repo=${git_url##*/}
 
-  cd "${REMOTE_SOURCES_DIR}/${git_repo}/${REMOTE_SOURCES_SUBDIR}"
-
-  # Source relevant cachito.env for downstream builds
-  cachito_path="${REMOTE_SOURCES_DIR}/${git_repo}"/cachito.env
-  if [[ -f "${cachito_path}" ]]; then
-    source "${cachito_path}"
-  fi
-
-  # Set branch using downstream CI_UPSTREAM_BRANCH variable
-  # ref: https://cpaas.pages.redhat.com/documentation/users/midstream/generating_files_from_templates.html#_environment_variables
-  if [[ -z "$(git branch --show-current)" ]] && [[ -n "${CI_UPSTREAM_BRANCH}" ]]; then
-    git checkout -b ${CI_UPSTREAM_BRANCH}
-  fi
-
+  cd "${SCRIPT_DIR}/../external/${git_repo}"
   echo "=="
+
+  # Set branch using .gitmodules config
+  parent_gitmodules="${SCRIPT_DIR}/../.gitmodules"
+  if [[ -f "${parent_gitmodules}" ]]; then
+    submodule_branch=$(git config --file "${parent_gitmodules}" --get "submodule.${git_repo}.branch" 2>/dev/null || echo "")
+    if [[ -n "${submodule_branch}" ]]; then
+      echo "* Creating branch '${submodule_branch}' for version generation"
+      git checkout -b "${submodule_branch}" 2>/dev/null || echo "* Branch '${submodule_branch}' already exists or cannot be created"
+    fi
+  fi
+
+  if { [[ "${current_branch}" == "release-"* ]] && [[ "${submodule_branch}" != "${current_branch}" ]]; } ||
+     { [[ -n "${previous_branch}" ]] && [[ "${submodule_branch}" != "${previous_branch}" ]]; }; then
+    echo "* Branch '${submodule_branch}' for '${git_repo}' does not match the current branch '${current_branch}' or the previous submodule branch '${previous_branch}'."
+    exit 1
+  fi
+
   echo "* Building binaries from ${git_url}"
   echo "* Executing build command: ${build_cmd}"
   ${build_cmd}
   echo "* Moving binaries from repo directory <repo>/${build_dir}/ to: ./${BUILD_DIR}/"
-  mv ${build_dir}/* ${SCRIPT_DIR}/../${BUILD_DIR}
+  mv "${build_dir}"/* "${SCRIPT_DIR}/../${BUILD_DIR}"
+  previous_branch=${submodule_branch}
 
   cd - 1>/dev/null
-done <${SCRIPT_DIR}/cli_map.csv
+done <"${SCRIPT_DIR}/cli_map.csv"

--- a/build/cli-packager.sh
+++ b/build/cli-packager.sh
@@ -4,11 +4,11 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-BUILD_DIR=${BUILD_DIR:-${SCRIPT_DIR}}
+BUILD_DIR=${BUILD_DIR:-"${SCRIPT_DIR}/_output"}
 
-cp ${SCRIPT_DIR}/../LICENSE ${BUILD_DIR}
+cp "${SCRIPT_DIR}"/../LICENSE "${BUILD_DIR}"
 
-cd ${BUILD_DIR}
+cd "${BUILD_DIR}"
 
 echo "# Packaging Windows binaries into zip archives"
 find . -type f -maxdepth 1 \


### PR DESCRIPTION
Versioning in the CLIs relies on Git branch metadata. In CPaaS, this was in a variable. For Konflux, we need to check out the branch specified in the git submodule.

ref: https://issues.redhat.com/browse/ACM-24266
Assisted-by: Cursor using claude-4-sonnet

Manual cherry-pick of:
- #222 