### PR TITLE
Add repository url label to container images

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -34,3 +34,6 @@ LABEL io.k8s.description="Serve ACM CLI binaries through the Red Hat Openshift c
 LABEL com.redhat.component="acm-cli-container"
 LABEL io.openshift.tags="data,images"
 LABEL cpe="cpe:/a:redhat:acm:2.15::el9"
+
+# Add repository URL label for traceability (ACM-23275)
+LABEL url="https://github.com/stolostron/acm-cli"


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** main

**Components affected:** acm-cli

**Branch details:** acm-cli (revision: main, fast-forwarded to: main)

**Label added:**
- url: https://github.com/stolostron/acm-cli

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.