### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,56 @@
+ARG ACM_VERSION
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+
+ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
+WORKDIR ${REPO_PATH}
+COPY . .
+
+# Build the HTTP server binary
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make build
+
+# Fetch and package imported binaries
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make sync-build-package
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_1.25 AS builder-rhel8
+
+ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
+WORKDIR ${REPO_PATH}
+COPY . .
+
+# Fetch and package imported binaries
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime BUILD_INPUT=cli_map_rhel8.csv make sync-build-package
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+ARG ACM_VERSION
+
+ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
+
+RUN microdnf install -y tar gzip
+
+# Copy binaries from builder
+COPY --from=builder ${REPO_PATH}/build/_output/* /acm-cli/
+RUN mv /acm-cli/PolicyGenerator.tar.gz /acm-cli/PolicyGenerator-rhel9.tar.gz
+COPY --from=builder-rhel8 ${REPO_PATH}/build/_output/* /acm-cli/
+RUN mv /acm-cli/PolicyGenerator.tar.gz /acm-cli/PolicyGenerator-rhel8.tar.gz
+RUN mv /acm-cli/acm-cli-server /usr/local/bin/
+
+# Copy license
+RUN mkdir licenses/
+COPY LICENSE licenses/
+
+# Run as non-root user
+USER 1001
+
+ENTRYPOINT [ "/usr/local/bin/acm-cli-server" ]
+
+LABEL name="rhacm2/acm-cli-rhel9"
+LABEL summary="Serve ACM CLI binaries"
+LABEL description="Serve ACM CLI binaries through the Red Hat Openshift console"
+LABEL url="https://github.com/stolostron/acm-cli"
+LABEL io.k8s.display-name="ACM CLI downloads"
+LABEL io.k8s.description="Serve ACM CLI binaries through the Red Hat Openshift console"
+LABEL com.redhat.component="acm-cli-container"
+LABEL io.openshift.tags="data,images"
+LABEL cpe="cpe:/a:redhat:acm:${ACM_VERSION}::el9"


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)