### PR TITLE
Remove external/ from .dockerignore for ART builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .github/
 .tekton/
 bin/
-external/
 test/


### PR DESCRIPTION
The external/ directory contains git submodules (policy-cli, policy-generator-plugin, allowlist-migration-mcoa) that are needed during the container build. ART's rebase process clones these repos directly into external/ as regular directories, but .dockerignore was excluding them from the Docker build context, causing build failures.

Removing this entry allows COPY . . to include the submodule content. This is safe for both build flows:
- ART: submodule content comes from COPY (sync-repos is skipped)
- Upstream Konflux: Tekton already checks out submodules before build, so COPY includes valid content

Question for maintainers: Is there any functional reason external/ was in .dockerignore beyond reducing build context size? We believe it was added because the original build fetched submodules at build time via git submodule update --init, making the build context copy unnecessary.

JIRA: HYPBLD-847