### PR TITLE
fix: update for dual fast-forward

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
           make gosec-scan
 
       - name: Validate build data
+        env:
+          VERSION_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
         run: |
           exit_code=0
 
@@ -43,17 +45,23 @@ jobs:
           <(sed -E 's/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder(-rhel8)?)$/\1\2\3/g; s/--chown=1001:1001 //' Dockerfile) \
           <(sed -E 's/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder(-rhel8)?)$/\1\2\3/g;' Dockerfile.rhtap); then
             echo "  ❌ Dockerfile and Dockerfile.rhtap are not in sync"
-            error_code=1
+            exit_code=1
           else
             echo "  ✅ Dockerfile and Dockerfile.rhtap are in sync"
           fi
 
           echo "=== Validate git submodule branches"
-          version="${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}"
+          version="${VERSION_REF}"
+          current_version=$(curl -s --fail https://raw.githubusercontent.com/stolostron/governance-policy-framework/refs/heads/main/CURRENT_VERSION | head -n 1)
+          if [[ -z "${current_version}" ]] || ! [[ "${current_version}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "* error: failed to fetch valid CURRENT_VERSION (got: '${current_version}')"
+            exit 1
+          fi
+
           if [[ ${version} =~ release-[0-9]+.[0-9]+ ]]; then
-            version="${version#release-}"
+            version=$(printf "%s\n%s\n" "${version#release-}" "${current_version}" | sort -V | head -n 1)
           else
-            version="$(curl -s --fail https://raw.githubusercontent.com/stolostron/governance-policy-framework/refs/heads/main/CURRENT_VERSION | head -n 1)"
+            version="${current_version}"
           fi
 
           for submodule in policy-cli policy-generator-plugin; do

--- a/.tekton/acm-cli-acm-217-pull-request.yaml
+++ b/.tekton/acm-cli-acm-217-pull-request.yaml
@@ -36,9 +36,6 @@ spec:
       value: 5d
     - name: build-source-image
       value: 'true'
-    - name: build-args
-      value:
-        - ACM_VERSION=2.17
     - name: build-platforms
       value:
         - linux/x86_64

--- a/.tekton/acm-cli-acm-217-push.yaml
+++ b/.tekton/acm-cli-acm-217-push.yaml
@@ -33,9 +33,6 @@ spec:
       value: '[{"type": "gomod", "path": "."},{"type": "gomod", "path": "external/policy-cli"},{"type": "gomod", "path": "external/policy-generator-plugin"},{"type": "gomod", "path": "external/allowlist-migration-mcoa"},{"type": "rpm", "path": "."}]'
     - name: build-source-image
       value: 'true'
-    - name: build-args
-      value:
-        - ACM_VERSION=2.17
     - name: build-platforms
       value:
         - linux/x86_64

--- a/.tekton/acm-cli-acm-50-pull-request.yaml
+++ b/.tekton/acm-cli-acm-50-pull-request.yaml
@@ -36,9 +36,6 @@ spec:
       value: 5d
     - name: build-source-image
       value: 'true'
-    - name: build-args
-      value:
-        - ACM_VERSION=2.17
     - name: build-platforms
       value:
         - linux/x86_64

--- a/.tekton/acm-cli-acm-50-push.yaml
+++ b/.tekton/acm-cli-acm-50-push.yaml
@@ -33,9 +33,6 @@ spec:
       value: '[{"type": "gomod", "path": "."},{"type": "gomod", "path": "external/policy-cli"},{"type": "gomod", "path": "external/policy-generator-plugin"},{"type": "gomod", "path": "external/allowlist-migration-mcoa"},{"type": "rpm", "path": "."}]'
     - name: build-source-image
       value: 'true'
-    - name: build-args
-      value:
-        - ACM_VERSION=2.17
     - name: build-platforms
       value:
         - linux/x86_64

--- a/.tekton/acm-cli-acm-51-pull-request.yaml
+++ b/.tekton/acm-cli-acm-51-pull-request.yaml
@@ -36,9 +36,6 @@ spec:
       value: 5d
     - name: build-source-image
       value: 'true'
-    - name: build-args
-      value:
-        - ACM_VERSION=2.17
     - name: build-platforms
       value:
         - linux/x86_64

--- a/.tekton/acm-cli-acm-51-push.yaml
+++ b/.tekton/acm-cli-acm-51-push.yaml
@@ -33,9 +33,6 @@ spec:
       value: '[{"type": "gomod", "path": "."},{"type": "gomod", "path": "external/policy-cli"},{"type": "gomod", "path": "external/policy-generator-plugin"},{"type": "gomod", "path": "external/allowlist-migration-mcoa"},{"type": "rpm", "path": "."}]'
     - name: build-source-image
       value: 'true'
-    - name: build-args
-      value:
-        - ACM_VERSION=2.17
     - name: build-platforms
       value:
         - linux/x86_64

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ RUN BUILD_INPUT=cli_map_rhel8.csv make sync-build-package
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
-ARG ACM_VERSION
-
 ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
 
 RUN microdnf install -y tar gzip
@@ -51,4 +49,3 @@ LABEL io.k8s.display-name="ACM CLI downloads"
 LABEL io.k8s.description="Serve ACM CLI binaries through the Red Hat Openshift console"
 LABEL com.redhat.component="acm-cli-container"
 LABEL io.openshift.tags="data,images"
-LABEL cpe="cpe:/a:redhat:acm:${ACM_VERSION}::el9"

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -21,8 +21,6 @@ RUN BUILD_INPUT=cli_map_rhel8.csv make sync-build-package
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
-ARG ACM_VERSION
-
 ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
 
 RUN microdnf install -y tar gzip
@@ -51,4 +49,3 @@ LABEL io.k8s.display-name="ACM CLI downloads"
 LABEL io.k8s.description="Serve ACM CLI binaries through the Red Hat Openshift console"
 LABEL com.redhat.component="acm-cli-container"
 LABEL io.openshift.tags="data,images"
-LABEL cpe="cpe:/a:redhat:acm:${ACM_VERSION}::el9"

--- a/build/cli-builder.sh
+++ b/build/cli-builder.sh
@@ -5,7 +5,6 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 BUILD_DIR=${BUILD_DIR:-"build/_output"}
 BUILD_INPUT=${BUILD_INPUT:-"cli_map.csv"}
-current_branch=$(git -C "${SCRIPT_DIR}/../" branch --show-current)
 
 if ! [[ -d "${SCRIPT_DIR}/../${BUILD_DIR}" ]]; then
   echo "="
@@ -43,9 +42,8 @@ while IFS=, read -r git_url build_cmd build_dir; do
     fi
   fi
 
-  if { [[ "${current_branch}" == "release-"* ]] && [[ "${submodule_branch}" != "${current_branch}" ]]; } ||
-     { [[ -n "${previous_branch}" ]] && [[ "${submodule_branch}" != "${previous_branch}" ]]; }; then
-    echo "* Branch '${submodule_branch}' for '${git_repo}' does not match the current branch '${current_branch}' or the previous submodule branch '${previous_branch}'."
+  if [[ -n "${previous_branch}" ]] && [[ "${submodule_branch}" != "${previous_branch}" ]]; then
+    echo "* Branch '${submodule_branch}' for '${git_repo}' does not match the previous submodule branch '${previous_branch}'."
     exit 1
   fi
 
@@ -55,8 +53,16 @@ while IFS=, read -r git_url build_cmd build_dir; do
   echo "* Moving binaries from repo directory <repo>/${build_dir}/ to: ./${BUILD_DIR}/"
   if [[ -f "${build_dir}" ]]; then
     mv "${build_dir}" "${SCRIPT_DIR}/../${BUILD_DIR}"
+  elif [[ -d "${build_dir}" ]]; then
+    if compgen -G "${build_dir}/*" >/dev/null; then
+      mv "${build_dir}"/* "${SCRIPT_DIR}/../${BUILD_DIR}"
+    else
+      echo "* Error: no files to move from ${build_dir}"
+      exit 1
+    fi
   else
-  mv "${build_dir}"/* "${SCRIPT_DIR}/../${BUILD_DIR}"
+    echo "* Error: build directory ${build_dir} does not exist."
+    exit 1
   fi
   previous_branch=${submodule_branch}
 


### PR DESCRIPTION
With dual fast-forward, the release version could be higher than the current submodules. In this case, handle the lower version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI validation now reliably fails when Dockerfiles or version checks are out of sync.
  * Release-branch handling is more consistent by deriving and validating expected release versions before comparison.
  * Build process strengthened with runtime retrieval/validation of the current version and more robust artifact handling for files vs. directories.
  * Image build metadata simplified by removing the explicit bundled version argument and related image label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->