### PR TITLE
fix(build): reset submodule tree before build to fix ART/cachi2 builds

### DIFF
--- a/build/cli-builder.sh
+++ b/build/cli-builder.sh
@@ -49,6 +49,11 @@ while IFS=, read -r git_url build_cmd build_dir; do
     exit 1
   fi
 
+  echo "* Cleaning file changes in the repo"
+  git status --porcelain
+  git restore .
+  git clean -fd
+
   echo "* Building binaries from ${git_url}"
   echo "* Executing build command: ${build_cmd}"
   ${build_cmd} || return_submodule_error


### PR DESCRIPTION
cachi2 prefetches Go modules inside submodule directories during source preparation, modifying files like go.sum. The policy-cli and policy-generator-plugin Makefiles have a clean-tree guard in their build-release target that rejects dirty trees. This causes ART builds to fail even though the prefetched deps are mounted separately at /cachi2 and unaffected by the reset.
Signed-off-by: Erin Murphy <erinmurp@redhat.com>