### PR TITLE
chore: upgrade to Go 1.26

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: builder
   namespace: stolostron
-  tag: go1.25-linux
+  tag: go1.26-linux

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,8 +42,8 @@ jobs:
 
           echo "=== Validate Dockerfiles"
           if ! diff \
-          <(sed -E 's/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder(-rhel8)?)$/\1\2\3/g; s/--chown=1001:1001 //' Dockerfile) \
-          <(sed -E 's/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder(-rhel8)?)$/\1\2\3/g;' Dockerfile.rhtap); then
+          <(sed -E '/ AS builder-rhel8$/d; s/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder)$/\1\2\3/g; s/--chown=1001:1001 //' Dockerfile) \
+          <(sed -E '/ AS builder-rhel8$/d; s/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder)$/\1\2\3/g;' Dockerfile.rhtap); then
             echo "  ❌ Dockerfile and Dockerfile.rhtap are not in sync"
             exit_code=1
           else

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
 WORKDIR ${REPO_PATH}

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
 WORKDIR ${REPO_PATH}
@@ -10,7 +10,7 @@ RUN make build
 # Fetch and package imported binaries
 RUN make sync-build-package
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.25 AS builder-rhel8
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.26 AS builder-rhel8
 
 ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
 WORKDIR ${REPO_PATH}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/stolostron/acm-cli
 
-go 1.25.0
+go 1.26.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version from 1.25 to 1.26 across CI and build configurations, including builder image tags, the module Go version directive, and OpenShift-compatible build images.
  * Adjusted the Dockerfile synchronization check in the CI workflow to improve how it normalizes and compares the `Dockerfile` and `Dockerfile.rhtap` builder stages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->