### PR TITLE
chore: update for ART build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-.github/
-.tekton/
-bin/
-test/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
           echo "=== Validate Dockerfiles"
           if ! diff \
           <(sed -E '/ AS builder-rhel8$/d; s/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder)$/\1\2\3/g; s/--chown=1001:1001 //' Dockerfile) \
-          <(sed -E '/ AS builder-rhel8$/d; s/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder)$/\1\2\3/g;' Dockerfile.rhtap); then
+          <(sed -E '/ AS builder-rhel8$/d; s/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder)$/\1\2\3/g; s/GOEXPERIMENT=strictfipsruntime //' Dockerfile.rhtap); then
             echo "  ❌ Dockerfile and Dockerfile.rhtap are not in sync"
             exit_code=1
           else

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ bin/
 gosec.json
 kubeconfig_*
 .go/
+
+# Build files
+content-sets.json
+labels.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR ${REPO_PATH}
 COPY . .
 
 # Build the HTTP server binary
-RUN make build
+RUN CGO_ENABLED=1 make build
 
 # Fetch and package imported binaries
 RUN make sync-build-package

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -5,7 +5,7 @@ WORKDIR ${REPO_PATH}
 COPY . .
 
 # Build the HTTP server binary
-RUN make build
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make build
 
 # Fetch and package imported binaries
 RUN make sync-build-package

--- a/build/cli-builder.sh
+++ b/build/cli-builder.sh
@@ -28,8 +28,11 @@ while IFS=, read -r git_url build_cmd build_dir; do
   fi
 
   git_repo=${git_url##*/}
+  git_dir=$(realpath "${SCRIPT_DIR}/../external/${git_repo}")
+  GIT="git -C ${git_dir}"
 
-  cd "${SCRIPT_DIR}/../external/${git_repo}" || return_submodule_error
+  [[ -d "${git_dir}" ]] || return_submodule_error
+
   echo "=="
 
   # Set branch using .gitmodules config
@@ -38,7 +41,7 @@ while IFS=, read -r git_url build_cmd build_dir; do
     submodule_branch=$(git config --file "${parent_gitmodules}" --get "submodule.${git_repo}.branch" 2>/dev/null || echo "")
     if [[ -n "${submodule_branch}" ]]; then
       echo "* Creating branch '${submodule_branch}' for version generation"
-      git checkout -b "${submodule_branch}" 2>/dev/null || echo "* Branch '${submodule_branch}' already exists or cannot be created"
+      ${GIT} checkout -b "${submodule_branch}" 2>/dev/null || echo "* Branch '${submodule_branch}' already exists or cannot be created"
     fi
   fi
 
@@ -49,22 +52,23 @@ while IFS=, read -r git_url build_cmd build_dir; do
 
   echo "* Building binaries from ${git_url}"
   echo "* Executing build command: ${build_cmd}"
-  ${build_cmd} || return_submodule_error
-  echo "* Moving binaries from repo directory <repo>/${build_dir}/ to: ./${BUILD_DIR}/"
-  if [[ -f "${build_dir}" ]]; then
-    mv "${build_dir}" "${SCRIPT_DIR}/../${BUILD_DIR}"
-  elif [[ -d "${build_dir}" ]]; then
-    if compgen -G "${build_dir}/*" >/dev/null; then
-      mv "${build_dir}"/* "${SCRIPT_DIR}/../${BUILD_DIR}"
+  (
+    cd "${git_dir}" || return_submodule_error
+    ${build_cmd} || return_submodule_error
+    echo "* Moving binaries from repo directory <repo>/${build_dir}/ to: ./${BUILD_DIR}/"
+    if [[ -f "${build_dir}" ]]; then
+      mv "${build_dir}" "${SCRIPT_DIR}/../${BUILD_DIR}"
+    elif [[ -d "${build_dir}" ]]; then
+      if compgen -G "${build_dir}/*" >/dev/null; then
+        mv "${build_dir}"/* "${SCRIPT_DIR}/../${BUILD_DIR}"
+      else
+        echo "* Error: no files to move from ${build_dir}"
+        exit 1
+      fi
     else
-      echo "* Error: no files to move from ${build_dir}"
+      echo "* Error: build directory ${build_dir} does not exist."
       exit 1
     fi
-  else
-    echo "* Error: build directory ${build_dir} does not exist."
-    exit 1
-  fi
+  )
   previous_branch=${submodule_branch}
-
-  cd - 1>/dev/null
 done <"${SCRIPT_DIR}/${BUILD_INPUT}"


### PR DESCRIPTION
- Add FIPS build flags to Dockerfile
- Remove `.dockerignore`
- Add build files to `.gitignore`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enabled CGO for Docker builds (`CGO_ENABLED=1`), including `GOEXPERIMENT=strictfipsruntime` for the RHTAP image build.
  - Updated Git/Docker ignore rules: emptied `.dockerignore` and expanded `.gitignore` to exclude additional build JSON files.
  - Improved the build script’s sub-repo path handling and artifact relocation into the shared outputs directory.

- **Tests / CI**
  - Updated CI Dockerfile validation to treat `GOEXPERIMENT=strictfipsruntime` differences as equivalent between `Dockerfile` and `Dockerfile.rhtap`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->