### PR TITLE
build: drop rhel8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,8 +42,8 @@ jobs:
 
           echo "=== Validate Dockerfiles"
           if ! diff \
-          <(sed -E '/ AS builder-rhel8$/d; s/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder)$/\1\2\3/g; s/--chown=1001:1001 //' Dockerfile) \
-          <(sed -E '/ AS builder-rhel8$/d; s/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder)$/\1\2\3/g; s/GOEXPERIMENT=strictfipsruntime //' Dockerfile.rhtap); then
+          <(sed -E 's/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder)$/\1\2\3/g; s/--chown=1001:1001 //' Dockerfile) \
+          <(sed -E 's/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder)$/\1\2\3/g; s/GOEXPERIMENT=strictfipsruntime //' Dockerfile.rhtap); then
             echo "  ❌ Dockerfile and Dockerfile.rhtap are not in sync"
             exit_code=1
           else

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,6 @@ RUN CGO_ENABLED=1 make build
 # Fetch and package imported binaries
 RUN make sync-build-package
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25 AS builder-rhel8
-
-ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
-WORKDIR ${REPO_PATH}
-COPY --chown=1001:1001 . .
-
-# Fetch and package imported binaries
-RUN BUILD_INPUT=cli_map_rhel8.csv make sync-build-package
-
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
@@ -28,8 +19,6 @@ RUN microdnf install -y tar gzip
 # Copy binaries from builder
 COPY --from=builder ${REPO_PATH}/build/_output/* /acm-cli/
 RUN mv /acm-cli/PolicyGenerator.tar.gz /acm-cli/PolicyGenerator-rhel9.tar.gz
-COPY --from=builder-rhel8 ${REPO_PATH}/build/_output/* /acm-cli/
-RUN mv /acm-cli/PolicyGenerator.tar.gz /acm-cli/PolicyGenerator-rhel8.tar.gz
 RUN mv /acm-cli/acm-cli-server /usr/local/bin/
 
 # Copy license

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -10,15 +10,6 @@ RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make build
 # Fetch and package imported binaries
 RUN make sync-build-package
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.26 AS builder-rhel8
-
-ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
-WORKDIR ${REPO_PATH}
-COPY . .
-
-# Fetch and package imported binaries
-RUN BUILD_INPUT=cli_map_rhel8.csv make sync-build-package
-
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
@@ -28,8 +19,6 @@ RUN microdnf install -y tar gzip
 # Copy binaries from builder
 COPY --from=builder ${REPO_PATH}/build/_output/* /acm-cli/
 RUN mv /acm-cli/PolicyGenerator.tar.gz /acm-cli/PolicyGenerator-rhel9.tar.gz
-COPY --from=builder-rhel8 ${REPO_PATH}/build/_output/* /acm-cli/
-RUN mv /acm-cli/PolicyGenerator.tar.gz /acm-cli/PolicyGenerator-rhel8.tar.gz
 RUN mv /acm-cli/acm-cli-server /usr/local/bin/
 
 # Copy license

--- a/build/cli_map_rhel8.csv
+++ b/build/cli_map_rhel8.csv
@@ -1,2 +1,0 @@
-GIT REPO URL,BUILD CMD,OUTPUT DIR
-https://github.com/stolostron/policy-generator-plugin,make build-binary,PolicyGenerator

--- a/test/cli_list.html
+++ b/test/cli_list.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <meta name="viewport" content="width=device-width">
 <pre>
-<a href="PolicyGenerator-rhel8.tar.gz">PolicyGenerator-rhel8.tar.gz</a>
 <a href="PolicyGenerator-rhel9.tar.gz">PolicyGenerator-rhel9.tar.gz</a>
 <a href="darwin-amd64-PolicyGenerator.tar.gz">darwin-amd64-PolicyGenerator.tar.gz</a>
 <a href="darwin-amd64-allowlist-migration.tar.gz">darwin-amd64-allowlist-migration.tar.gz</a>


### PR DESCRIPTION
See https://github.com/stolostron/acm-cli/pull/461#issuecomment-4894010017

rhel8 builder does not support go 1.26

ref: https://redhat.atlassian.net/browse/ACM-35531

Assisted by Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Docker build and packaging steps to use the newer RHEL 9-based builder flow.
  * Runtime images now reference the RHEL 9 package artifact naming consistently.
  * The CLI artifact list now shows the updated download entry, removing the older RHEL 8 option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->