### PR TITLE
2.17 build: drop rhel8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,8 @@ jobs:
 
           echo "=== Validate Dockerfiles"
           if ! diff \
-          <(sed -E 's/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder(-rhel8)?)$/\1\2\3/g; s/--chown=1001:1001 //' Dockerfile) \
-          <(sed -E 's/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder(-rhel8)?)$/\1\2\3/g; s/GOEXPERIMENT=strictfipsruntime //' Dockerfile.rhtap); then
+          <(sed -E 's/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder)$/\1\2\3/g; s/--chown=1001:1001 //' Dockerfile) \
+          <(sed -E 's/^(FROM ).*([0-9]+\.[0-9]+).*( AS builder)$/\1\2\3/g; s/GOEXPERIMENT=strictfipsruntime //' Dockerfile.rhtap); then
             echo "  ❌ Dockerfile and Dockerfile.rhtap are not in sync"
             error_code=1
           else

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,6 @@ RUN CGO_ENABLED=1 make build
 # Fetch and package imported binaries
 RUN make sync-build-package
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25 AS builder-rhel8
-
-ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
-WORKDIR ${REPO_PATH}
-COPY --chown=1001:1001 . .
-
-# Fetch and package imported binaries
-RUN BUILD_INPUT=cli_map_rhel8.csv make sync-build-package
-
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG ACM_VERSION
@@ -30,8 +21,6 @@ RUN microdnf install -y tar gzip
 # Copy binaries from builder
 COPY --from=builder ${REPO_PATH}/build/_output/* /acm-cli/
 RUN mv /acm-cli/PolicyGenerator.tar.gz /acm-cli/PolicyGenerator-rhel9.tar.gz
-COPY --from=builder-rhel8 ${REPO_PATH}/build/_output/* /acm-cli/
-RUN mv /acm-cli/PolicyGenerator.tar.gz /acm-cli/PolicyGenerator-rhel8.tar.gz
 RUN mv /acm-cli/acm-cli-server /usr/local/bin/
 
 # Copy license

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -10,15 +10,6 @@ RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make build
 # Fetch and package imported binaries
 RUN make sync-build-package
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.26 AS builder-rhel8
-
-ENV REPO_PATH=/go/src/github.com/stolostron/acm-cli
-WORKDIR ${REPO_PATH}
-COPY . .
-
-# Fetch and package imported binaries
-RUN BUILD_INPUT=cli_map_rhel8.csv make sync-build-package
-
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG ACM_VERSION
@@ -30,8 +21,6 @@ RUN microdnf install -y tar gzip
 # Copy binaries from builder
 COPY --from=builder ${REPO_PATH}/build/_output/* /acm-cli/
 RUN mv /acm-cli/PolicyGenerator.tar.gz /acm-cli/PolicyGenerator-rhel9.tar.gz
-COPY --from=builder-rhel8 ${REPO_PATH}/build/_output/* /acm-cli/
-RUN mv /acm-cli/PolicyGenerator.tar.gz /acm-cli/PolicyGenerator-rhel8.tar.gz
 RUN mv /acm-cli/acm-cli-server /usr/local/bin/
 
 # Copy license

--- a/build/cli_map_rhel8.csv
+++ b/build/cli_map_rhel8.csv
@@ -1,2 +1,0 @@
-GIT REPO URL,BUILD CMD,OUTPUT DIR
-https://github.com/stolostron/policy-generator-plugin,make build-binary,PolicyGenerator

--- a/test/cli_list.html
+++ b/test/cli_list.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <meta name="viewport" content="width=device-width">
 <pre>
-<a href="PolicyGenerator-rhel8.tar.gz">PolicyGenerator-rhel8.tar.gz</a>
 <a href="PolicyGenerator-rhel9.tar.gz">PolicyGenerator-rhel9.tar.gz</a>
 <a href="darwin-amd64-PolicyGenerator.tar.gz">darwin-amd64-PolicyGenerator.tar.gz</a>
 <a href="darwin-amd64-allowlist-migration.tar.gz">darwin-amd64-allowlist-migration.tar.gz</a>


### PR DESCRIPTION
## Summary
- Backport of #468 to `release-2.17`
- Remove RHEL8 builder stage from `Dockerfile` and `Dockerfile.rhtap`
- Delete `build/cli_map_rhel8.csv` and stop serving `PolicyGenerator-rhel8.tar.gz`
- Update CI Dockerfile sync check to drop `builder-rhel8` normalization

rhel8 builder does not support go 1.26

ref: https://redhat.atlassian.net/browse/ACM-35531

## Test plan
- [x] CI lint job passes (Dockerfile sync validation, fmt, gosec)
- [x] CI test job passes (`make build-image` + `make e2e-test`)
- [x] Served file list matches `test/cli_list.html` (no `PolicyGenerator-rhel8.tar.gz`)
- [x] `PolicyGenerator-rhel9.tar.gz` still served


Made with [Cursor](https://cursor.com)